### PR TITLE
refactor-role 타입 재설정

### DIFF
--- a/src/main/java/com/project/Instagram/domain/member/entity/Member.java
+++ b/src/main/java/com/project/Instagram/domain/member/entity/Member.java
@@ -25,10 +25,10 @@ public class Member extends BaseTimeEntity {
     private String username;
 
     @Column(name = "member_role")
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "member_roles", joinColumns = @JoinColumn(name = "member_id"))
     @Enumerated(EnumType.STRING)
-    @ElementCollection(fetch = FetchType.EAGER)
-    private List<MemberRole> roles = new ArrayList<>();
+    private Set<MemberRole> roles = new HashSet<>();
 
     @Column(name = "member_password", nullable = false)
     private String password;
@@ -58,13 +58,13 @@ public class Member extends BaseTimeEntity {
     }
 
     @Builder
-    public Member(String username, String name, String password, String email, List<MemberRole> roles) {
+    public Member(String username, String name, String password, String email, Set<MemberRole> roles) {
         this.username = username;
         this.name = name;
         this.password = password;
         this.email = email;
-        this.roles = roles;
         this.gender = Gender.PRIVATE;
+        this.roles = roles;
     }
 
     public void setRestoreMembership(String username, String encryptedPassword, String name) {

--- a/src/main/java/com/project/Instagram/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/project/Instagram/domain/member/entity/MemberRole.java
@@ -1,5 +1,19 @@
 package com.project.Instagram.domain.member.entity;
 
-public enum MemberRole {
-    ROLE_USER, ROLE_ADMIN;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+
+@RequiredArgsConstructor
+public enum MemberRole implements GrantedAuthority {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    @Getter
+    private final String role;
+
+    @Override
+    public String getAuthority() {
+        return role;
+    }
 }

--- a/src/main/java/com/project/Instagram/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/Instagram/domain/member/service/MemberService.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -77,7 +78,7 @@ public class MemberService {
     }
 
     private void createNewMember(SignUpRequest signUpRequest) {
-        List<MemberRole> roles = customAuthorityUtils.createRole(signUpRequest.getEmail());
+        Set<MemberRole> roles = customAuthorityUtils.createRole(signUpRequest.getEmail());
         Member newMember = convertRegisterRequestToMember(signUpRequest, roles);
         String encryptedPassword = bCryptPasswordEncoder.encode(newMember.getPassword());
         newMember.setEncryptedPassword(encryptedPassword);
@@ -98,7 +99,7 @@ public class MemberService {
         emailAuthService.sendSignUpCode(email);
     }
 
-    private Member convertRegisterRequestToMember(SignUpRequest signUpRequest, List<MemberRole> roles) {
+    private Member convertRegisterRequestToMember(SignUpRequest signUpRequest, Set<MemberRole> roles) {
         return Member.builder()
                 .username(signUpRequest.getUsername())
                 .name(signUpRequest.getName())

--- a/src/main/java/com/project/Instagram/domain/member/service/RefreshTokenService.java
+++ b/src/main/java/com/project/Instagram/domain/member/service/RefreshTokenService.java
@@ -23,7 +23,7 @@ public class RefreshTokenService {
             List<RefreshToken> refreshTokens = refreshTokenRedisRepository.findAllByMemberId(memberId);
             for (RefreshToken refreshToken : refreshTokens)
                 refreshTokenRedisRepository.delete(refreshToken);
-        } catch (Exception e) {
+        } catch (BusinessException e) {
             throw new BusinessException(ErrorCode.MEMBER_ID_REFRESH_TOKEN_DOES_NOT_EXIST);
         }
     }

--- a/src/main/java/com/project/Instagram/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/Instagram/global/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import com.project.Instagram.global.jwt.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -59,8 +58,12 @@ public class SecurityConfig {
                 .exceptionHandling()
                 .and()
                 .authorizeRequests(authorize -> authorize
-                        .anyRequest().permitAll());
-
+                        .antMatchers("/api/**/sign-up").permitAll()
+                        .antMatchers("/api/**/email").permitAll()
+                        .antMatchers("/api/**/reset").permitAll()
+                        .antMatchers("/api/**/member").permitAll()
+                        .anyRequest().hasAnyRole("USER","ADMIN")
+                );
         return http.build();
     }
     @Bean

--- a/src/main/java/com/project/Instagram/global/error/ErrorCode.java
+++ b/src/main/java/com/project/Instagram/global/error/ErrorCode.java
@@ -17,7 +17,9 @@ public enum ErrorCode {
     EMAIL_SEND_FAIL(500, "이메일 전송 중 오류가 발생했습니다."),
     FILE_CONVERT_FAIL(500, "변환할 수 없는 파일입니다."),
     MEMBER_ID_REFRESH_TOKEN_DOES_NOT_EXIST(500, "해당 memberId의 refresh token 이 존재하지 않습니다."),
-    LOGIN_INFORMATION_ERROR(500, "현재 사용자의 ID를 가져오는 중 문제가 발생했습니다.");
+    LOGIN_INFORMATION_ERROR(500, "현재 사용자의 ID를 가져오는 중 문제가 발생했습니다."),
+    INVALID_ROLE(500,"MemberRole의 role을 가져오는데 실패했습니다.");
+
 
 
 

--- a/src/main/java/com/project/Instagram/global/jwt/CustomAuthorityUtils.java
+++ b/src/main/java/com/project/Instagram/global/jwt/CustomAuthorityUtils.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
@@ -14,21 +14,16 @@ public class CustomAuthorityUtils {
     @Value("${mail.address.admin}")
     private String adminMailAddress;
 
-    private final List<MemberRole> ADMIN_ROLES = List.of(MemberRole.ROLE_ADMIN, MemberRole.ROLE_USER);
-    private final List<MemberRole> USER_ROLES = List.of(MemberRole.ROLE_USER);
-
-    public List<GrantedAuthority> createAuthorities(List<MemberRole> roles) {
-        List<GrantedAuthority> authorities = roles.stream()
-                .map(role -> new SimpleGrantedAuthority(role.toString()))
+    public List<GrantedAuthority> createAuthorities(Set<MemberRole> roles) {
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority(role.getAuthority()))
                 .collect(Collectors.toList());
-        return authorities;
     }
 
-    public List<MemberRole> createRole(String email) {
+    public Set<MemberRole> createRole(String email) {
         if (email.equals(adminMailAddress)) {
-            return ADMIN_ROLES;
+            return new HashSet<>(Arrays.asList(MemberRole.ADMIN, MemberRole.USER));
         }
-        return USER_ROLES;
+        return Collections.singleton(MemberRole.USER);
     }
-
 }


### PR DESCRIPTION
### 내용
- ArrayList -> HashSet으로 설정
순서보장도 필요 없고, 역할에 따른 접근 권한만 부여하는 역할이여서 처리 속도가 더 빠른 Set으로 변경

- MemberRole의 열거형을 변환하면서 실제 권한 체크시 못 읽어오는 문제 해결
직접 enum 클래스에 private으로 String 타입 role 객체를 만들어서  GrantedAuthority를 상속받아 제공하는 getAuthority 메서드 활용 